### PR TITLE
prevent users from using Kernel with Bun

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -188,10 +188,12 @@ export class Kernel {
     ...opts
   }: ClientOptions = {}) {
     // Check for Bun runtime in a way that avoids type errors if Bun is not defined
-    if (typeof globalThis !== 'undefined' && typeof (globalThis as any).Bun !== 'undefined' && (globalThis as any).Bun.version) {
-      throw new Errors.KernelError(
-        "The Bun runtime is not supported. Please use a different runtime.",
-      );
+    if (
+      typeof globalThis !== 'undefined' &&
+      typeof (globalThis as any).Bun !== 'undefined' &&
+      (globalThis as any).Bun.version
+    ) {
+      throw new Errors.KernelError('The Bun runtime is not supported. Please use a different runtime.');
     }
 
     if (apiKey === undefined) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -190,7 +190,7 @@ export class Kernel {
     // Check for Bun runtime in a way that avoids type errors if Bun is not defined
     if (typeof globalThis !== 'undefined' && typeof (globalThis as any).Bun !== 'undefined' && (globalThis as any).Bun.version) {
       throw new Errors.KernelError(
-        'The Bun runtime is not supported. Please use a different runtime.',
+        "The Bun runtime is not supported. Please use a different runtime.",
       );
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -191,9 +191,12 @@ export class Kernel {
     if (
       typeof globalThis !== 'undefined' &&
       typeof (globalThis as any).Bun !== 'undefined' &&
-      (globalThis as any).Bun.version
+      (globalThis as any).Bun.version &&
+      !readEnv('KERNEL_SUPPRESS_BUN_WARNING')
     ) {
-      throw new Errors.KernelError('The Bun runtime is not supported. Please use a different runtime.');
+      loggerFor(this).warn(
+        'The Bun runtime was detected. Playwright may have CDP connection issues, proceed with caution. Suppress this warning by setting the KERNEL_SUPPRESS_BUN_WARNING environment variable to true',
+      );
     }
 
     if (apiKey === undefined) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -187,6 +187,13 @@ export class Kernel {
     apiKey = readEnv('KERNEL_API_KEY'),
     ...opts
   }: ClientOptions = {}) {
+    // Check for Bun runtime in a way that avoids type errors if Bun is not defined
+    if (typeof globalThis !== 'undefined' && typeof (globalThis as any).Bun !== 'undefined' && (globalThis as any).Bun.version) {
+      throw new Errors.KernelError(
+        'The Bun runtime is not supported. Please use a different runtime.',
+      );
+    }
+
     if (apiKey === undefined) {
       throw new Errors.KernelError(
         "The KERNEL_API_KEY environment variable is missing or empty; either provide it, or instantiate the Kernel client with an apiKey option, like new Kernel({ apiKey: 'My API Key' }).",


### PR DESCRIPTION
<span data-mesa-description="start"></span>
## TL;DR
Disables the `Kernel` client from running in the Bun JavaScript runtime.

## Why we made these changes
To prevent `Kernel` from being used in an unsupported or incompatible environment, avoiding potential issues or undefined behavior.

## What changed?
- `src/client.ts`: Modified the `Kernel` client constructor to include a runtime check that throws a `KernelError` if Bun is detected as the current runtime.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<span data-mesa-description="end"></span>