### PR TITLE
ci: add Semgrep SAST scanning on pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,17 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: kernel/security-workflows/.github/workflows/semgrep.yml@main
+    with:
+      extra-configs: '--config p/javascript --config p/typescript --config p/trailofbits'
+      codebase-description: 'Stainless-generated TypeScript/Node SDK for the Kernel API (public npm package used by customers)'
+    secrets: inherit


### PR DESCRIPTION
## Summary

Follow-up from the INC-51 postmortem ([KERNEL-1191](https://linear.app/onkernel/issue/KERNEL-1191/finalize-scope-of-repos-under-elevated-vulnerability-management)): the Kernel MCP vulnerability was missed in part because the MCP repo was not subscribed to the shared Semgrep workflow. Expanding the scope to the customer-facing SDKs so the same gap can't happen there.

This PR adds `.github/workflows/semgrep.yml` that calls the reusable workflow in [kernel/security-workflows](https://github.com/kernel/security-workflows). Runs on every PR targeting \`main\` with the agent-powered triage flow already used in \`kernel\`, \`kernel-images\`, \`cli\`, \`kernel-mcp-server\`, etc.

Semgrep configs: \`p/javascript\`, \`p/typescript\`, \`p/trailofbits\`.

Uses org-level secrets already provisioned for existing subscribers (\`CURSOR_API_KEY\`, \`CURSOR_PREFERRED_MODEL\`, \`ADMIN_APP_ID\`, \`ADMIN_APP_PRIVATE_KEY\`, \`SOCKET_API_TOKEN\`) via \`secrets: inherit\`.

### Stainless caveat

This SDK is Stainless-generated. Stainless doesn't appear to manage arbitrary files under \`.github/workflows/\`, but if the next regeneration wipes this file, we'll need to either add it to the Stainless config or restore it via a post-generation step.

## Test plan

- [ ] CI runs on this PR itself (first scan of the repo). Verify the \`Semgrep / scan\` check appears and completes.
- [ ] If findings are produced, confirm the triage agent posts comments as expected.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CI job that runs a reusable workflow with `secrets: inherit` and `pull-requests: write` permissions, so misconfiguration could expose secrets or enable unwanted PR comments. Otherwise it’s isolated to CI and doesn’t change runtime behavior.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `.github/workflows/semgrep.yml`, that runs on PRs targeting `main` and invokes the shared `kernel/security-workflows` Semgrep workflow.
> 
> The scan is configured with the `p/javascript`, `p/typescript`, and `p/trailofbits` rule sets and grants the job PR write permissions (to post results) while inheriting org secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db0f1391e105a7c8c39fd0559c8b0a68f71fd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->