### PR TITLE
ci: add centralized vuln remediation workflow

### DIFF
--- a/.github/workflows/vuln-remediation.yml
+++ b/.github/workflows/vuln-remediation.yml
@@ -1,0 +1,17 @@
+name: Vulnerability Remediation
+
+on:
+  schedule:
+    - cron: '0 3 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  remediate:
+    uses: kernel/security-workflows/.github/workflows/vuln-remediation.yml@main
+    with:
+      setup-bun: true
+    secrets: inherit

--- a/.github/workflows/vuln-remediation.yml
+++ b/.github/workflows/vuln-remediation.yml
@@ -12,6 +12,4 @@ permissions:
 jobs:
   remediate:
     uses: kernel/security-workflows/.github/workflows/vuln-remediation.yml@main
-    with:
-      setup-bun: true
     secrets: inherit

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,1 @@
+version: 2


### PR DESCRIPTION
Thin caller to the reusable 3-stage pipeline (triage → fix → PR) in kernel/security-workflows.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a scheduled/dispatchable GitHub Actions workflow that can open PRs and update repo contents, so misconfiguration could create noisy or unintended automated changes.
> 
> **Overview**
> Introduces a new GitHub Actions workflow, `vuln-remediation.yml`, that runs weekly (and on manual trigger) and delegates to the reusable `kernel/security-workflows` vulnerability remediation pipeline with write access to contents and pull requests.
> 
> Adds `socket.yml` with `version: 2` to enable/initialize Socket’s configuration for this repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c75c6d157c05d9bd92ca9294efb89f81c65ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->