### PR TITLE
release: 0.54.0

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 112
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/kernel/kernel-64dac369ae935b0318cd611e1735d45359a663eb55cf43fbb8b09e9dd814d7a2.yml
-openapi_spec_hash: cc0c6a4e716977df4b9eab5f4658d41b
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/kernel/kernel-a33e59aa1758ba51f13538838ecd70b0a23ed69739b3022e8c2ce0622e42b904.yml
+openapi_spec_hash: c042d2f6880c927be09aa9fa79d7241e
 config_hash: 08d55086449943a8fec212b870061a3f

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 112
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/kernel/kernel-38c6ce8b0ce54e6c62517b9635acaf65369c26cdb1b55eb66290c13a8ab2b33d.yml
-openapi_spec_hash: e6f6ed157b1e318d1a1db72fd1d27091
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/kernel/kernel-64dac369ae935b0318cd611e1735d45359a663eb55cf43fbb8b09e9dd814d7a2.yml
+openapi_spec_hash: cc0c6a4e716977df4b9eab5f4658d41b
 config_hash: 08d55086449943a8fec212b870061a3f

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 112
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/kernel/kernel-7d2d29d7598105d50e5118e0bc5ac654361a92cb95555705dbd1d236848e1456.yml
-openapi_spec_hash: 10002eae793e08f81932239bbc72b503
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/kernel/kernel-38c6ce8b0ce54e6c62517b9635acaf65369c26cdb1b55eb66290c13a8ab2b33d.yml
+openapi_spec_hash: e6f6ed157b1e318d1a1db72fd1d27091
 config_hash: 08d55086449943a8fec212b870061a3f

--- a/src/resources/auth/connections.ts
+++ b/src/resources/auth/connections.ts
@@ -213,6 +213,12 @@ export interface ManagedAuth {
   profile_name: string;
 
   /**
+   * Whether browser sessions for this connection are recorded by default for
+   * debugging. Can be overridden per-login.
+   */
+  record_session: boolean;
+
+  /**
    * Whether credentials are saved after every successful login. One-time codes
    * (TOTP, SMS, etc.) are not saved.
    */
@@ -615,6 +621,12 @@ export interface ManagedAuthCreateRequest {
   proxy?: ManagedAuthCreateRequest.Proxy;
 
   /**
+   * Whether to record browser sessions for this connection by default. Useful for
+   * debugging. Can be overridden per-login. Defaults to false.
+   */
+  record_session?: boolean;
+
+  /**
    * Whether to save credentials after every successful login. Defaults to true.
    * One-time codes (TOTP, SMS, etc.) are not saved.
    */
@@ -701,6 +713,11 @@ export interface ManagedAuthUpdateRequest {
    * caller's org.
    */
   proxy?: ManagedAuthUpdateRequest.Proxy;
+
+  /**
+   * Whether to record browser sessions for this connection by default
+   */
+  record_session?: boolean;
 
   /**
    * Whether to save credentials after every successful login
@@ -1081,6 +1098,12 @@ export interface ConnectionCreateParams {
   proxy?: ConnectionCreateParams.Proxy;
 
   /**
+   * Whether to record browser sessions for this connection by default. Useful for
+   * debugging. Can be overridden per-login. Defaults to false.
+   */
+  record_session?: boolean;
+
+  /**
    * Whether to save credentials after every successful login. Defaults to true.
    * One-time codes (TOTP, SMS, etc.) are not saved.
    */
@@ -1166,6 +1189,11 @@ export interface ConnectionUpdateParams {
   proxy?: ConnectionUpdateParams.Proxy;
 
   /**
+   * Whether to record browser sessions for this connection by default
+   */
+  record_session?: boolean;
+
+  /**
    * Whether to save credentials after every successful login
    */
   save_credentials?: boolean;
@@ -1236,6 +1264,12 @@ export interface ConnectionLoginParams {
    * caller's org.
    */
   proxy?: ConnectionLoginParams.Proxy;
+
+  /**
+   * Override the connection's default for recording this login's browser session.
+   * When omitted, the connection's record_session default is used.
+   */
+  record_session?: boolean;
 }
 
 export namespace ConnectionLoginParams {

--- a/src/resources/auth/connections.ts
+++ b/src/resources/auth/connections.ts
@@ -213,8 +213,8 @@ export interface ManagedAuth {
   profile_name: string;
 
   /**
-   * Whether browser sessions for this connection are recorded by default for
-   * debugging. Can be overridden per-login.
+   * Whether to record browser session replays for this connection by default. Useful
+   * for debugging login flows. Can be overridden per-login.
    */
   record_session: boolean;
 

--- a/src/resources/auth/connections.ts
+++ b/src/resources/auth/connections.ts
@@ -272,7 +272,8 @@ export interface ManagedAuth {
   credential?: ManagedAuth.Credential;
 
   /**
-   * Fields awaiting input (present when flow_step=awaiting_input)
+   * Fields awaiting input (present when flow_step=awaiting_input; may also be
+   * present with awaiting_external_action as fallback actions)
    */
   discovered_fields?: Array<ManagedAuth.DiscoveredField> | null;
 
@@ -362,13 +363,14 @@ export interface ManagedAuth {
   login_url?: string;
 
   /**
-   * MFA method options (present when flow_step=awaiting_input and MFA selection
-   * required)
+   * MFA method options (present when flow_step=awaiting_input; may also be present
+   * with awaiting_external_action as fallback actions)
    */
   mfa_options?: Array<ManagedAuth.MfaOption> | null;
 
   /**
-   * SSO buttons available (present when flow_step=awaiting_input)
+   * SSO buttons available (present when flow_step=awaiting_input; may also be
+   * present with awaiting_external_action as fallback actions)
    */
   pending_sso_buttons?: Array<ManagedAuth.PendingSSOButton> | null;
 
@@ -384,7 +386,8 @@ export interface ManagedAuth {
 
   /**
    * Non-MFA choices presented during the auth flow, such as account selection or org
-   * pickers (present when flow_step=awaiting_input).
+   * pickers (present when flow_step=awaiting_input; may also be present with
+   * awaiting_external_action as fallback actions).
    */
   sign_in_options?: Array<ManagedAuth.SignInOption> | null;
 
@@ -830,7 +833,8 @@ export namespace ConnectionFollowResponse {
     timestamp: string;
 
     /**
-     * Fields awaiting input (present when flow_step=AWAITING_INPUT).
+     * Fields awaiting input (present when flow_step=AWAITING_INPUT; may also be
+     * present with AWAITING_EXTERNAL_ACTION as fallback actions).
      */
     discovered_fields?: Array<ManagedAuthStateEvent.DiscoveredField>;
 
@@ -866,13 +870,14 @@ export namespace ConnectionFollowResponse {
     live_view_url?: string;
 
     /**
-     * MFA method options (present when flow_step=AWAITING_INPUT and MFA selection
-     * required).
+     * MFA method options (present when flow_step=AWAITING_INPUT; may also be present
+     * with AWAITING_EXTERNAL_ACTION as fallback actions).
      */
     mfa_options?: Array<ManagedAuthStateEvent.MfaOption>;
 
     /**
-     * SSO buttons available (present when flow_step=AWAITING_INPUT).
+     * SSO buttons available (present when flow_step=AWAITING_INPUT; may also be
+     * present with AWAITING_EXTERNAL_ACTION as fallback actions).
      */
     pending_sso_buttons?: Array<ManagedAuthStateEvent.PendingSSOButton>;
 
@@ -883,7 +888,8 @@ export namespace ConnectionFollowResponse {
 
     /**
      * Non-MFA choices presented during the auth flow, such as account selection or org
-     * pickers (present when flow_step=AWAITING_INPUT).
+     * pickers (present when flow_step=AWAITING_INPUT; may also be present with
+     * AWAITING_EXTERNAL_ACTION as fallback actions).
      */
     sign_in_options?: Array<ManagedAuthStateEvent.SignInOption>;
 

--- a/tests/api-resources/auth/connections.test.ts
+++ b/tests/api-resources/auth/connections.test.ts
@@ -38,6 +38,7 @@ describe('resource connections', () => {
       health_check_interval: 3600,
       login_url: 'https://netflix.com/login',
       proxy: { id: 'id', name: 'name' },
+      record_session: false,
       save_credentials: true,
     });
   });
@@ -136,7 +137,10 @@ describe('resource connections', () => {
     await expect(
       client.auth.connections.login(
         'id',
-        { proxy: { id: 'id', name: 'name' } },
+        {
+          proxy: { id: 'id', name: 'name' },
+          record_session: true,
+        },
         { path: '/_stainless_unknown_path' },
       ),
     ).rejects.toThrow(Kernel.NotFoundError);


### PR DESCRIPTION
## Summary
- feat: Add opt-in record_session flag to managed auth
- Update managed auth connection types with record_session on create/update/login requests

Generated by Stainless on the `next` branch. Manual PR since release-please didn't auto-create after v0.53.0 shipped before the API changes merged.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `record_session` parameters to managed auth connection create/update/login types, which changes the request/response contract for auth flows and could affect downstream typing/serialization expectations.
> 
> **Overview**
> Adds an opt-in `record_session` flag to managed auth connections, allowing callers to default-enable browser session recording per connection and override it per-login via `ConnectionLoginParams`.
> 
> Updates the generated Typescript types/docs for managed auth flow payloads to note that `discovered_fields`, `mfa_options`, `pending_sso_buttons`, and `sign_in_options` may also appear during `AWAITING_EXTERNAL_ACTION`, and refreshes the OpenAPI spec reference plus related tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de53ea541914c933e3828db73a4104ef8f27c447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->