### PR TITLE
Fix offset auto-pagination skipping every other page

### DIFF
--- a/src/core/pagination.ts
+++ b/src/core/pagination.ts
@@ -152,6 +152,11 @@ export class OffsetPagination<Item> extends AbstractPage<Item> {
     // adding the current page length on top skips a full page per iteration.
     const offset = this.next_offset;
     if (offset == null) {
+      if (this.has_more) {
+        throw new KernelError(
+          'Server reported X-Has-More: true without an X-Next-Offset header; refusing to silently truncate pagination',
+        );
+      }
       return null;
     }
 

--- a/src/core/pagination.ts
+++ b/src/core/pagination.ts
@@ -148,15 +148,18 @@ export class OffsetPagination<Item> extends AbstractPage<Item> {
   }
 
   nextPageRequestOptions(): PageRequestOptions | null {
-    const offset = this.next_offset ?? 0;
-    const length = this.getPaginatedItems().length;
-    const currentCount = offset + length;
+    // X-Next-Offset already holds the offset where the next page starts;
+    // adding the current page length on top skips a full page per iteration.
+    const offset = this.next_offset;
+    if (offset == null) {
+      return null;
+    }
 
     return {
       ...this.options,
       query: {
         ...maybeObj(this.options.query),
-        offset: currentCount,
+        offset,
       },
     };
   }

--- a/src/core/pagination.ts
+++ b/src/core/pagination.ts
@@ -148,8 +148,11 @@ export class OffsetPagination<Item> extends AbstractPage<Item> {
   }
 
   nextPageRequestOptions(): PageRequestOptions | null {
-    // X-Next-Offset already holds the offset where the next page starts;
-    // adding the current page length on top skips a full page per iteration.
+    // X-Next-Offset is the absolute start of the next page, or 0 on the last
+    // page (the API's stop sentinel). The old code added the current page
+    // length on top, skipping a full page per iteration. Only a positive
+    // offset advances; 0 is a value the server affirmatively sent to mean
+    // "no more", so we stop on it (matching the Go SDK pager).
     const offset = this.next_offset;
     if (offset == null) {
       if (this.has_more) {
@@ -157,6 +160,9 @@ export class OffsetPagination<Item> extends AbstractPage<Item> {
           'Server reported X-Has-More: true without an X-Next-Offset header; refusing to silently truncate pagination',
         );
       }
+      return null;
+    }
+    if (offset === 0) {
       return null;
     }
 

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -2,9 +2,16 @@ import Kernel, { KernelError } from '@onkernel/sdk';
 import { OffsetPagination } from '@onkernel/sdk/core/pagination';
 import type { FinalRequestOptions } from '@onkernel/sdk/internal/request-options';
 
-const client = new Kernel({ apiKey: 'test-api-key', fetch: () => Promise.reject(new Error('unexpected request')) });
+const client = new Kernel({
+  apiKey: 'test-api-key',
+  fetch: () => Promise.reject(new Error('unexpected request')),
+});
 
-function pageWith(headers: Record<string, string>, items: unknown[], offset?: number): OffsetPagination<unknown> {
+function pageWith(
+  headers: Record<string, string>,
+  items: unknown[],
+  offset?: number,
+): OffsetPagination<unknown> {
   const options: FinalRequestOptions = {
     method: 'get',
     path: '/proxies',

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -34,9 +34,11 @@ describe('OffsetPagination', () => {
     expect(page.hasNextPage()).toBe(false);
   });
 
-  test('stops when X-Next-Offset is 0, the last-page sentinel', () => {
-    const page = pageWith({ 'x-next-offset': '0', 'x-has-more': 'false' }, new Array(50).fill({}), 100);
-    expect(page.hasNextPage()).toBe(false);
+  test('stops on the X-Next-Offset 0 sentinel even when X-Has-More is true', () => {
+    // Call nextPageRequestOptions directly with has_more=true so the has_more
+    // gate in hasNextPage() cannot mask it: the 0 offset alone must stop.
+    const page = pageWith({ 'x-next-offset': '0', 'x-has-more': 'true' }, new Array(50).fill({}), 100);
+    expect(page.nextPageRequestOptions()).toBeNull();
   });
 
   test('stops when X-Has-More is false even with a positive X-Next-Offset', () => {

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -1,0 +1,39 @@
+import Kernel from '@onkernel/sdk';
+import { OffsetPagination } from '@onkernel/sdk/core/pagination';
+import type { FinalRequestOptions } from '@onkernel/sdk/internal/request-options';
+
+const client = new Kernel({ apiKey: 'test-api-key', fetch: () => Promise.reject(new Error('unexpected request')) });
+
+function pageWith(headers: Record<string, string>, items: unknown[], offset?: number): OffsetPagination<unknown> {
+  const options: FinalRequestOptions = {
+    method: 'get',
+    path: '/proxies',
+    query: offset === undefined ? {} : { offset },
+  };
+  return new OffsetPagination(client, new Response('[]', { headers }), items, options);
+}
+
+describe('OffsetPagination', () => {
+  test('requests the next page at exactly X-Next-Offset', () => {
+    // X-Next-Offset already holds the next page's start. Adding the current
+    // page length on top (the old behavior) skipped a full page per iteration.
+    const page = pageWith({ 'x-next-offset': '100', 'x-has-more': 'true' }, new Array(100).fill({}), 0);
+    expect(page.nextPageRequestOptions()?.query).toEqual({ offset: 100 });
+  });
+
+  test('stops when X-Next-Offset is absent', () => {
+    const page = pageWith({ 'x-has-more': 'true' }, new Array(100).fill({}));
+    expect(page.nextPageRequestOptions()).toBeNull();
+    expect(page.hasNextPage()).toBe(false);
+  });
+
+  test('stops when X-Has-More is false', () => {
+    const page = pageWith({ 'x-next-offset': '200', 'x-has-more': 'false' }, new Array(50).fill({}), 100);
+    expect(page.hasNextPage()).toBe(false);
+  });
+
+  test('stops on an empty page', () => {
+    const page = pageWith({ 'x-next-offset': '300', 'x-has-more': 'true' }, [], 200);
+    expect(page.hasNextPage()).toBe(false);
+  });
+});

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -1,4 +1,4 @@
-import Kernel from '@onkernel/sdk';
+import Kernel, { KernelError } from '@onkernel/sdk';
 import { OffsetPagination } from '@onkernel/sdk/core/pagination';
 import type { FinalRequestOptions } from '@onkernel/sdk/internal/request-options';
 
@@ -21,13 +21,18 @@ describe('OffsetPagination', () => {
     expect(page.nextPageRequestOptions()?.query).toEqual({ offset: 100 });
   });
 
-  test('stops when X-Next-Offset is absent', () => {
-    const page = pageWith({ 'x-has-more': 'true' }, new Array(100).fill({}));
+  test('stops cleanly when the last page omits X-Next-Offset', () => {
+    const page = pageWith({ 'x-has-more': 'false' }, new Array(50).fill({}), 100);
     expect(page.nextPageRequestOptions()).toBeNull();
     expect(page.hasNextPage()).toBe(false);
   });
 
-  test('stops when X-Has-More is false', () => {
+  test('stops when X-Next-Offset is 0, the last-page sentinel', () => {
+    const page = pageWith({ 'x-next-offset': '0', 'x-has-more': 'false' }, new Array(50).fill({}), 100);
+    expect(page.hasNextPage()).toBe(false);
+  });
+
+  test('stops when X-Has-More is false even with a positive X-Next-Offset', () => {
     const page = pageWith({ 'x-next-offset': '200', 'x-has-more': 'false' }, new Array(50).fill({}), 100);
     expect(page.hasNextPage()).toBe(false);
   });
@@ -35,5 +40,10 @@ describe('OffsetPagination', () => {
   test('stops on an empty page', () => {
     const page = pageWith({ 'x-next-offset': '300', 'x-has-more': 'true' }, [], 200);
     expect(page.hasNextPage()).toBe(false);
+  });
+
+  test('refuses to silently truncate when X-Has-More is true but X-Next-Offset is missing', () => {
+    const page = pageWith({ 'x-has-more': 'true' }, new Array(100).fill({}));
+    expect(() => page.hasNextPage()).toThrow(KernelError);
   });
 });


### PR DESCRIPTION
## Bug

`OffsetPagination.nextPageRequestOptions()` computed the next request offset as `next_offset + items.length`. But `X-Next-Offset` already holds the offset where the **next** page starts (the API sets it to `offset + limit`), so every iteration skipped a full page: with 250 items at limit 100, `for await` yields items 0–99 and 200–249 — 100–199 silently vanish. `X-Has-More` still terminates the loop, so nothing ever errored.

Same bug class as kernel/kernel#2401 investigated; the Python SDK has the identical flaw (PR incoming), while the Go SDK uses the header directly and was always correct.

## Fix

Use `X-Next-Offset` verbatim as the next request's offset, and stop paginating when the header is absent. Termination via `X-Has-More: false` and empty pages is unchanged.

## Why a hand-written commit to generated code

Stainless's hosted generator is winding down post-acquisition, so a template-level fix is not coming. While the service still runs, this commit rides Stainless's custom-code three-way merge; after sunset it is simply the code. `tests/pagination.test.ts` pins the arithmetic and all three termination conditions.

## Note for kernel/kernel#2401

That PR's `stainless.yaml` remap (`X-Offset` count-start semantics) must **not** merge: it fixes nothing that this commit doesn't, and it breaks the Go SDK (single-page truncation via its `next != 0` sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Correctness fix for all offset-paginated list calls changes which items clients receive; behavior is strictly more correct but may surface the new KernelError if the API ever returns inconsistent headers.
> 
> **Overview**
> **Fixes silent data loss** in `for await` / auto-pagination over offset-based list APIs (deployments, apps, invocations, browsers, profiles, proxies, etc.).
> 
> `OffsetPagination.nextPageRequestOptions()` no longer sets the next request to `X-Next-Offset + current page length`. It now passes **`X-Next-Offset` as the next `offset` query param**, matching the API (and the Go SDK). The previous math skipped every other page while `X-Has-More` still ended the loop, so results looked “complete” but were missing rows.
> 
> **Termination and safety:** pagination stops when `X-Next-Offset` is missing (unless `X-Has-More: false`), when the header is **`0`** (last-page sentinel), or on empty pages / `X-Has-More: false` as before. If **`X-Has-More: true`** but **`X-Next-Offset` is absent**, `hasNextPage()` now throws **`KernelError`** instead of truncating quietly.
> 
> Adds **`tests/pagination.test.ts`** to lock in next-offset arithmetic and the stop/error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3184109680279c5c6565f730c874ae04c52a58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->