### PR TITLE
fix: don't misroute telemetry/events to the browser VM

### DIFF
--- a/src/lib/browser-routing.ts
+++ b/src/lib/browser-routing.ts
@@ -28,7 +28,10 @@ export class BrowserRouteCache {
 }
 
 const BROWSER_ROUTING_SUBRESOURCES_ENV = 'KERNEL_BROWSER_ROUTING_SUBRESOURCES';
-const DEFAULT_BROWSER_ROUTING_SUBRESOURCES = ['curl', 'telemetry'];
+// Path prefixes eligible for direct-to-VM routing. "telemetry/stream" is the live
+// SSE endpoint (served by the VM); "telemetry/events" is a historical read served
+// by the control plane (S2) and must NOT be here.
+const DEFAULT_BROWSER_ROUTING_SUBRESOURCES = ['curl', 'telemetry/stream'];
 const BROWSER_ROUTE_CACHEABLE_PATH = /^\/(?:v\d+\/)?browsers(?:\/[^/]+)?\/?$/;
 const BROWSER_POOL_ACQUIRE_PATH = /^\/(?:v\d+\/)?browser_pools\/[^/]+\/acquire\/?$/;
 const BROWSER_DELETE_BY_ID_PATH = /^\/(?:v\d+\/)?browsers\/([^/]+)\/?$/;
@@ -62,7 +65,7 @@ export function createRoutingFetch(
     cache: BrowserRouteCache;
   },
 ): Fetch {
-  const allowed = new Set([...subresources].map((value) => value.trim()).filter(Boolean));
+  const allowed = [...subresources].map((value) => value.trim().replace(/^\/+|\/+$/g, '')).filter(Boolean);
   const apiOrigin = new URL(apiBaseURL).origin;
 
   return async (input, init) => {
@@ -202,6 +205,16 @@ function populateCache(value: unknown, cache: BrowserRouteCache): void {
   }
 }
 
+// matchesDirectVMPrefix reports whether tail (the path after browsers/{id}/) is
+// covered by an allow prefix, matching on segment boundaries: "telemetry/stream"
+// matches "telemetry/stream" and "telemetry/stream/...", but not "telemetry/events"
+// or "telemetry/streamfoo". Keeps historical control-plane reads (telemetry/events,
+// served from S2) off the VM.
+export function matchesDirectVMPrefix(tail: string, prefixes: readonly string[]): boolean {
+  const t = tail.replace(/^\/+|\/+$/g, '');
+  return prefixes.some((p) => t === p || t.startsWith(p + '/'));
+}
+
 async function routeRequest(
   innerFetch: Fetch,
   {
@@ -214,7 +227,7 @@ async function routeRequest(
     request: Request;
   },
   apiOrigin: string,
-  allowed: ReadonlySet<string>,
+  allowed: readonly string[],
   cache: BrowserRouteCache,
 ): Promise<Response> {
   const url = new URL(request.url);
@@ -229,7 +242,7 @@ async function routeRequest(
 
   const sessionId = decodeURIComponent(match[1] ?? '');
   const subresource = match[2] ?? '';
-  if (!sessionId || !allowed.has(subresource)) {
+  if (!sessionId || !matchesDirectVMPrefix(subresource + (match[3] ?? ''), allowed)) {
     return innerFetch(input, init);
   }
   const route = cache.get(sessionId);

--- a/tests/lib/browser-routing.test.ts
+++ b/tests/lib/browser-routing.test.ts
@@ -4,6 +4,7 @@ import {
   BrowserRouteCache,
   browserRoutingSubresourcesFromEnv,
   createRoutingFetch,
+  matchesDirectVMPrefix,
 } from '../../src/lib/browser-routing';
 
 describe('browser routing', () => {
@@ -381,10 +382,21 @@ describe('browser routing', () => {
     ).rejects.toThrow(/unsupported HTTP method/i);
   });
 
-  test('defaults browser routing subresources to curl and telemetry when env is unset', async () => {
+  test('defaults browser routing subresources to curl and telemetry/stream when env is unset', async () => {
     await withBrowserRoutingEnv(undefined, async () => {
-      expect(browserRoutingSubresourcesFromEnv()).toEqual(['curl', 'telemetry']);
+      expect(browserRoutingSubresourcesFromEnv()).toEqual(['curl', 'telemetry/stream']);
     });
+  });
+
+  test('allowlist matching is segment-boundary aware (telemetry/events stays on the control plane)', () => {
+    const prefixes = ['curl', 'telemetry/stream'];
+    expect(matchesDirectVMPrefix('telemetry/stream', prefixes)).toBe(true);
+    expect(matchesDirectVMPrefix('telemetry/stream/x', prefixes)).toBe(true);
+    expect(matchesDirectVMPrefix('telemetry/events', prefixes)).toBe(false);
+    expect(matchesDirectVMPrefix('telemetry/streaming-config', prefixes)).toBe(false);
+    expect(matchesDirectVMPrefix('telemetry', prefixes)).toBe(false);
+    expect(matchesDirectVMPrefix('curl/raw', prefixes)).toBe(true);
+    expect(matchesDirectVMPrefix('fs/read', prefixes)).toBe(false);
   });
 
   test('routes telemetry stream calls to the VM /telemetry/stream path by default', async () => {


### PR DESCRIPTION
Node companion to kernel-go-sdk#126 / kernel-python-sdk#122. The direct-to-VM routing allowlist matched on the subresource segment (`telemetry`), so the new historical `GET /browsers/{id}/telemetry/events` (served by the control plane from S2) was routed to the session VM (live `telemetry/stream` SSE only) once a session was route-cached → failures/wrong data.

**Fix (in `src/lib/`, Stainless-preserved → durable across regens):**
- Allowlist entries are full path-prefixes (`curl`, `telemetry/stream`), not bare subresources.
- Segment-boundary matching (`matchesDirectVMPrefix`): `telemetry/stream` matches `telemetry/stream[/...]` but NOT `telemetry/events` or `telemetry/streamfoo`.
- Safe by default: anything not allowlisted (incl. future endpoints) → control plane.
- Adds a regression vector; updates the default-config assertion. **17/17 routing tests pass.**

Should land in **0.70.0**, which introduces `telemetry/events`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing for cached browser sessions; wrong matching would break telemetry or other browser subresource calls, but scope is limited to the allowlist logic with regression tests.
> 
> **Overview**
> Fixes direct-to-VM browser routing so **`GET …/telemetry/events`** stays on the control plane instead of being sent to the session VM when a route is cached.
> 
> The allowlist no longer keys off the first path segment alone (`telemetry`). Defaults and env-driven entries are **path prefixes** (`curl`, `telemetry/stream`), normalized without leading/trailing slashes. Routing now checks the full tail after `browsers/{id}/` via **`matchesDirectVMPrefix`**, which only matches on segment boundaries (e.g. `telemetry/stream` and subpaths, not `telemetry/events` or `telemetry/streamfoo`).
> 
> Adds unit tests for prefix matching and updates the default subresource assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f75392bef0d5fabebcf0d6e86f3a8ea8794138e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->