### PR TITLE
fix: preserve abort signals in browser routing

### DIFF
--- a/src/lib/browser-routing.ts
+++ b/src/lib/browser-routing.ts
@@ -262,10 +262,11 @@ async function routeRequest(
 
   const headers = new Headers(request.headers);
   headers.delete('authorization');
-  return innerFetch(target.toString(), buildRoutedInit(request, init, headers));
+  return innerFetch(target.toString(), buildRoutedInit(input, request, init, headers));
 }
 
 function buildRoutedInit(
+  input: RequestInfo,
   request: Request,
   originalInit: RequestInit | undefined,
   headers: Headers,
@@ -276,7 +277,7 @@ function buildRoutedInit(
     method,
     headers,
     redirect: request.redirect,
-    signal: request.signal,
+    signal: originalInit?.signal ?? (input instanceof Request ? input.signal : undefined),
   } as RequestInit & Record<string, unknown>;
 
   delete routedInit['body'];

--- a/tests/lib/browser-routing.test.ts
+++ b/tests/lib/browser-routing.test.ts
@@ -188,6 +188,42 @@ describe('browser routing', () => {
     });
   });
 
+  test('preserves the caller abort signal for routed requests', async () => {
+    const controller = new AbortController();
+    const cache = new BrowserRouteCache();
+    cache.set({
+      sessionId: 'sess-1',
+      baseURL: 'http://browser-session.test/browser/kernel',
+      jwt: 'token-abc',
+    });
+
+    let routedSignal: AbortSignal | null | undefined;
+    const wrappedFetch = createRoutingFetch(
+      async (_input, init) => {
+        routedSignal = init?.signal;
+        return new Response(null, { status: 204 });
+      },
+      {
+        apiBaseURL: 'https://api.example/',
+        subresources: ['telemetry/stream'],
+        cache,
+      },
+    );
+
+    await wrappedFetch('https://api.example/browsers/sess-1/telemetry/stream', {
+      signal: controller.signal,
+    });
+
+    expect(routedSignal === controller.signal).toBe(true);
+
+    const request = new Request('https://api.example/browsers/sess-1/telemetry/stream', {
+      signal: controller.signal,
+    });
+    await wrappedFetch(request);
+
+    expect(routedSignal === request.signal).toBe(true);
+  });
+
   test('ignores browser responses that do not include a usable jwt', async () => {
     await withBrowserRoutingEnv('process', async () => {
       const kernel = new Kernel({


### PR DESCRIPTION
## summary

- preserve the caller-provided abort signal when rewriting browser requests for direct VM routing
- retain signals supplied through both `RequestInit` and `Request` inputs
- add a deterministic regression test that fails with the previous dependent signal

## why

Reconstructing a `Request` creates a dependent signal. Passing that derived signal to the routed fetch can intermittently leave streamed response reads blocked after the caller aborts.

## tests

- `yarn test --runInBand`
- `yarn lint`
- `yarn build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fetch routing for live SSE/telemetry streams where incorrect abort handling caused intermittent hangs; change is narrow but behavior-critical for cancellation.
> 
> **Overview**
> Direct-to-VM browser routing no longer forwards the **dependent** `AbortSignal` from the reconstructed `Request` when issuing the routed `innerFetch`. **`buildRoutedInit`** now takes the original `input` and sets `signal` from `originalInit?.signal`, or from the caller’s `Request` when `input` is a `Request`, so aborts on allowlisted paths like **`telemetry/stream`** propagate to the underlying fetch and streamed reads can unwind after cancel.
> 
> A regression test asserts the routed fetch receives the same signal reference for both URL + `RequestInit` and `Request` call shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eec02c6b4327c1d9e225a99edc8f37d7ac47c6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->